### PR TITLE
Github actions и фикс картинок

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,8 +19,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Setup grunt & dependencies
-        run: npm install -g grunt-cli
-        run: npm ci
+        run: |
+          npm install -g grunt-cli
+          npm ci
       - name: Build docs
         run: grunt docs
       - name: Deploy

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup other dependencies
         run: npm install --safe-dev
       - name: Build docs
-        run: grunt docs
+        run: grunt pages
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.6
         with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,10 +18,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Setup grunt & dependencies
-        run: |
-          npm install -g grunt-cli
-          npm ci
+      - name: Setup grunt
+        run: npm install -g grunt-cli
+      - name: Setup other dependencies
+        run: npm install --safe-dev
       - name: Build docs
         run: grunt docs
       - name: Deploy

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,33 @@
+name: Build docs & Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Setup grunt & dependencies
+        run: npm install -g grunt-cli
+        run: npm ci
+      - name: Build docs
+        run: grunt docs
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.6
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: master
+          BRANCH: gh-pages
+          FOLDER: out
+          single-commit: true

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup other dependencies
         run: npm install --safe-dev
       - name: Build docs
-        run: grunt pages
+        run: grunt docs
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.6
         with:

--- a/documentation/static-pages/guides/world/dimensions.md
+++ b/documentation/static-pages/guides/world/dimensions.md
@@ -46,7 +46,7 @@ In this minimalistic example we are creating a single generation layer between y
 
 ## Single Layer Generation
 
-![Generation Example #1](../assets/images/pages/dimensions-1.jpg)
+![Generation Example #1](../../../assets/images/pages/dimensions-1.jpg)
 
 ```js
 var generator = Dimensions.newGenerator({
@@ -111,7 +111,7 @@ yConversion: [
 
 Creates a landscape where most of the blocks are concentrated in the bottom part of the layer:
 
-![Generation Example #2](../assets/images/pages/dimensions-2.jpg)
+![Generation Example #2](../../../assets/images/pages/dimensions-2.jpg)
 
 ```js
 yConversion: [
@@ -123,7 +123,7 @@ yConversion: [
 
 Creates a landscape where most of the blocks are concentrated in the bottom and the top parts of the layer, leaving the middle empty:
 
-![Generation Example #3](../assets/images/pages/dimensions-3.jpg)
+![Generation Example #3](../../../assets/images/pages/dimensions-3.jpg)
 
 ```js
 yConversion: [
@@ -137,11 +137,11 @@ yConversion: [
 
 Creates a more complex landscape like the one displayed on the image:
 
-![Generation Example #4](../assets/images/pages/dimensions-4.jpg)
+![Generation Example #4](../../../assets/images/pages/dimensions-4.jpg)
 
 ## Dimension Materials
 
-![Generation Example #5](../assets/images/pages/dimensions-5.jpg)
+![Generation Example #5](../../../assets/images/pages/dimensions-5.jpg)
 
 ```js
 var generator = Dimensions.newGenerator({
@@ -192,7 +192,7 @@ Materials noise can be used for single generation layer to consist of blocks of 
 
 When you need a more complex generation, you can use multiple layers. Layers are generated in the order they were listed in the description object, so you should want to generate a water layer at first. Let's take a look at some example:
 
-![Generation Example #6](../assets/images/pages/dimensions-6.jpg)
+![Generation Example #6](../../../assets/images/pages/dimensions-6.jpg)
 
 ```js
 var generator = Dimensions.newGenerator({
@@ -249,6 +249,6 @@ Heightmap is a 2-dimensional (x, z) noise that is used to generate a general hei
 
 To make mountains less rounded, we can change the count of octaves of the stone layer. Say, we had 6 octaves in the stone layer, the generation should look like this:
 
-![Generation Example #7](../assets/images/pages/dimensions-7.jpg)
+![Generation Example #7](../../../assets/images/pages/dimensions-7.jpg)
 
 However, you should always think twice before adding a lot of octaves and layers. Massive generation requires more time for calculations, so it is generally better to use layer conversions and heightmap of the existing layer then create multiple layers with more noise octaves.

--- a/documentation/static-pages/guides/world/dimensions.md
+++ b/documentation/static-pages/guides/world/dimensions.md
@@ -46,7 +46,7 @@ In this minimalistic example we are creating a single generation layer between y
 
 ## Single Layer Generation
 
-![Generation Example #1](../assets/images/pages/dimensions-1.jpg)
+![Generation Example #1](assets/images/pages/dimensions-1.jpg)
 
 ```js
 var generator = Dimensions.newGenerator({

--- a/documentation/static-pages/guides/world/dimensions.md
+++ b/documentation/static-pages/guides/world/dimensions.md
@@ -46,7 +46,7 @@ In this minimalistic example we are creating a single generation layer between y
 
 ## Single Layer Generation
 
-![Generation Example #1](assets/images/pages/dimensions-1.jpg)
+![Generation Example #1](../assets/images/pages/dimensions-1.jpg)
 
 ```js
 var generator = Dimensions.newGenerator({

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -46,26 +46,6 @@ module.exports = function (grunt) {
                     },
                 ],
             },
-            headers: {
-                files: [
-                    {
-                        expand: true,
-                        src: 'headers/*',
-                        flatten: true,
-                        dest: 'out/',
-                    },
-                ],
-            },
-            images: {
-                files: [
-                    {
-                        expand: true,
-                        src: 'documentation/images/*',
-                        flatten: true,
-                        dest: 'out/assets/images/pages',
-                    },
-                ],
-            },
         },
     });
 
@@ -73,5 +53,4 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-typedoc');
     grunt.registerTask('docs', ['concat', 'typedoc', 'copy']);
-    grunt.registerTask('pages', ['typedoc', 'copy:images']);
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -46,6 +46,26 @@ module.exports = function (grunt) {
                     },
                 ],
             },
+            headers: {
+                files: [
+                    {
+                        expand: true,
+                        src: 'headers/*',
+                        flatten: true,
+                        dest: 'out/',
+                    },
+                ],
+            },
+            images: {
+                files: [
+                    {
+                        expand: true,
+                        src: 'documentation/images/*',
+                        flatten: true,
+                        dest: 'out/assets/images/pages',
+                    },
+                ],
+            },
         },
     });
 
@@ -53,4 +73,5 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-typedoc');
     grunt.registerTask('docs', ['concat', 'typedoc', 'copy']);
+    grunt.registerTask('pages', ['typedoc', 'copy:images']);
 };


### PR DESCRIPTION
Добавлено новое действие для Github Pages при пуше в master:
1. Обычная генерация документации
2. Создание ветки `gh-pages` и последующий деплой на Github Pages не дожидаясь ручной загрузки на основной сайт с документацией

Изменены пути на странице `Dimensions` в связи с глобальным переездом страниц