### PR TITLE
Пофикшена ссылка на core-engine.d.ts

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
                     readme: 'readme.md',
                     theme: 'pages-plugin',
                     listInvalidSymbolLinks: 'true',
-                    'sourcefile-url-prefix': 'https://github.com/zheka2304/innercore-mod-toolchain/tree/master/toolchain-mod/toolchain/declarations/',
+                    'sourcefile-url-prefix': 'https://github.com/mineprogramming/innercore-docs/blob/gh-pages/',
                 },
                 src: ['headers/core-engine.d.ts'],
             },


### PR DESCRIPTION
Когда было добавлено действие `Docs build & Deploy`, была создана независимая ветка `gh-pages` для сайта.
На этой ветке `grunt` генерировал полноценный сайт и готовые заголовки для innercore.

После того как это было сделано, стало возможным изменение ссылки на ссылаемый файл `core-engine.d.ts` для документации.